### PR TITLE
Delete sdk start references

### DIFF
--- a/packages/background/src/controllers/BlankController.ts
+++ b/packages/background/src/controllers/BlankController.ts
@@ -2111,7 +2111,7 @@ export default class BlankController extends EventEmitter {
         });
 
         // As we don't care about the result here, ignore errors in transaction result
-        result.catch(() => { });
+        result.catch(() => {});
 
         // Approve it
         try {
@@ -2161,7 +2161,7 @@ export default class BlankController extends EventEmitter {
                 });
 
             // As we don't care about the result here, ignore errors in transaction result
-            result.catch(() => { });
+            result.catch(() => {});
 
             const { nativeCurrency, iconUrls } = this.networkController.network;
             const logo = iconUrls ? iconUrls[0] : '';
@@ -2232,7 +2232,7 @@ export default class BlankController extends EventEmitter {
             });
 
         // As we don't care about the result here, ignore errors in transaction result
-        result.catch(() => { });
+        result.catch(() => {});
 
         return transactionMeta;
     }
@@ -2551,7 +2551,7 @@ export default class BlankController extends EventEmitter {
         // Force network to be mainnet if it is not provided
         //let network: string = AvailableNetworks.MAINNET;
         // RPCh Experimental version
-        let network = "Gnosis_RPCh";
+        let network = 'Gnosis_RPCh';
 
         if (defaultNetwork) {
             const fullNetwork =
@@ -2935,7 +2935,7 @@ export default class BlankController extends EventEmitter {
      * Remove all entries in the book
      *
      */
-    private async addressBookClear({ }: RequestAddressBookClear): Promise<boolean> {
+    private async addressBookClear({}: RequestAddressBookClear): Promise<boolean> {
         return this.addressBookController.clear();
     }
 
@@ -2971,7 +2971,7 @@ export default class BlankController extends EventEmitter {
      *
      * @returns - A map with the entries
      */
-    private async addressBookGet({ }: RequestAddressBookGet): Promise<NetworkAddressBook> {
+    private async addressBookGet({}: RequestAddressBookGet): Promise<NetworkAddressBook> {
         return this.addressBookController.get();
     }
 

--- a/packages/background/src/controllers/NetworkController.ts
+++ b/packages/background/src/controllers/NetworkController.ts
@@ -751,12 +751,6 @@ export default class NetworkController extends BaseController<NetworkControllerS
             // Instantiate provider and wait until it's ready
             const newNetworkProvider = this.getProviderFromName(network.name);
 
-            // start RPCh provider
-            if (newNetworkProvider instanceof RPChProvider) {
-                await (newNetworkProvider as RPChProvider).sdk.start();
-                console.log('rpch provider started');
-            }
-
             // Update provider listeners
             this._updateListeners(newNetworkProvider);
 
@@ -866,15 +860,6 @@ export default class NetworkController extends BaseController<NetworkControllerS
             async () => {
                 try {
                     // call net_version to easily identify this call on the reporting
-
-                    // start rpch
-                    if (
-                        provider instanceof RPChProvider &&
-                        !provider.sdk.isReady
-                    ) {
-                        await (provider as RPChProvider).sdk.start();
-                        console.log('rpch provider started');
-                    }
 
                     return provider.send('net_version', []);
                 } catch (error) {


### PR DESCRIPTION
Blocked by Rpc-h/RPCh#300

## Description
This pull request aims to use the new version of the RPCh `ethers` package.
Calls to the `start` function of the sdk are removed because it is now done internally in the sdk.